### PR TITLE
Transfer stimuli degrees

### DIFF
--- a/model_tools/activations/pytorch.py
+++ b/model_tools/activations/pytorch.py
@@ -103,9 +103,9 @@ class PytorchWrapper:
         return g
 
 
-def load_preprocess_images(image_filepaths, image_size):
+def load_preprocess_images(image_filepaths, image_size, normalize_mean=(0.485, 0.456, 0.406), normalize_std=(0.229, 0.224, 0.225)):
     images = load_images(image_filepaths)
-    images = preprocess_images(images, image_size=image_size)
+    images = preprocess_images(images, image_size=image_size, normalize_mean=normalize_mean, normalize_std=normalize_std)
     return images
 
 
@@ -125,18 +125,18 @@ def load_image(image_filepath):
             return rgb_image
 
 
-def preprocess_images(images, image_size):
-    preprocess = torchvision_preprocess_input(image_size)
+def preprocess_images(images, image_size, normalize_mean=(0.485, 0.456, 0.406), normalize_std=(0.229, 0.224, 0.225)):
+    preprocess = torchvision_preprocess_input(image_size, normalize_mean, normalize_std)
     images = [preprocess(image) for image in images]
     images = np.concatenate(images)
     return images
 
 
-def torchvision_preprocess_input(image_size):
+def torchvision_preprocess_input(image_size, normalize_mean=(0.485, 0.456, 0.406), normalize_std=(0.229, 0.224, 0.225)):
     from torchvision import transforms
     return transforms.Compose([
         transforms.Resize(image_size),
-        torchvision_preprocess(),
+        torchvision_preprocess(normalize_mean, normalize_std),
     ])
 
 

--- a/model_tools/brain_transformation/behavior.py
+++ b/model_tools/brain_transformation/behavior.py
@@ -57,8 +57,11 @@ class ProbabilitiesMapping(BrainModel):
     def start_task(self, task: BrainModel.Task, fitting_stimuli):
         assert task in [BrainModel.Task.passive, BrainModel.Task.probabilities]
         self.current_task = task
-
-        fitting_features = self.activations_model(fitting_stimuli, layers=[self.layer])
+        if type(self.layer) is not list:
+            layers = [self.layer]
+        else:
+            layers = self.layer
+        fitting_features = self.activations_model(fitting_stimuli, layers=layers)
         fitting_features = fitting_features.transpose('presentation', 'neuroid')
         assert all(fitting_features['image_id'].values == fitting_stimuli['image_id'].values), \
             "image_id ordering is incorrect"
@@ -67,7 +70,11 @@ class ProbabilitiesMapping(BrainModel):
     def look_at(self, stimuli):
         if self.current_task is BrainModel.Task.passive:
             return
-        features = self.activations_model(stimuli, layers=[self.layer])
+        if type(self.layer) is not list:
+            layers = [self.layer]
+        else:
+            layers = self.layer
+        features = self.activations_model(stimuli, layers=layers)
         features = features.transpose('presentation', 'neuroid')
         prediction = self.classifier.predict_proba(features)
         return prediction


### PR DESCRIPTION
Allows pytorch models load_preprocess_images to accept normalizations other than the default.
Corrects bug that was crashing models' behavioral layers.