### PR TITLE
add legacy support for LogitsBehavior class

### DIFF
--- a/model_tools/brain_transformation/behavior.py
+++ b/model_tools/brain_transformation/behavior.py
@@ -78,6 +78,13 @@ class LabelBehavior(BrainModel):
         return BehavioralAssembly([choices], coords=coords, dims=['choice', 'presentation'])
 
 
+LogitsBehavior = LabelBehavior  # LogitsBehavior is deprecated. Use LabelBehavior instead.
+"""
+legacy support; still used in old candidate_models submissions
+https://github.com/brain-score/candidate_models/blob/fa965c452bd17c6bfcca5b991fdbb55fd5db618f/candidate_models/model_commitments/cornets.py#L13
+"""
+
+
 class LabelToImagenetIndices:
     airplane_indices = [404]
     bear_indices = [294, 295, 296, 297]

--- a/tests/brain_transformation/test_behavior.py
+++ b/tests/brain_transformation/test_behavior.py
@@ -2,13 +2,12 @@ import functools
 import numpy as np
 import os
 import pytest
-import torch.random
 import xarray as xr
-from brainio.assemblies import BehavioralAssembly
-from brainio.stimuli import StimulusSet
 from pathlib import Path
 from pytest import approx
 
+from brainio.assemblies import BehavioralAssembly
+from brainio.stimuli import StimulusSet
 from brainscore.benchmarks.rajalingham2018 import _DicarloRajalingham2018
 from brainscore.benchmarks.screen import place_on_screen
 from brainscore.metrics.image_level_behavior import I2n
@@ -64,7 +63,7 @@ class TestLabelBehavior:
         activations_model = model_ctr()
         brain_model = ModelCommitment(identifier=activations_model.identifier, activations_model=activations_model,
                                       layers=['relu1', 'relu2'], behavioral_readout_layer='relu2')
-        stimuli = self.mock_stimulus_set()
+        stimuli = mock_stimulus_set()
         choice_labels = ['dog', 'cat', 'bear', 'bird']
         brain_model.start_task(BrainModel.Task.label, choice_labels)
         behavior = brain_model.look_at(stimuli)
@@ -75,12 +74,39 @@ class TestLabelBehavior:
         assert behavior.sel(stimulus_id='1').values.item() == 'bear'
         assert behavior.sel(stimulus_id='2').values.item() == 'bird'
 
-    def mock_stimulus_set(self):
-        stimuli = StimulusSet({'stimulus_id': ['1', '2'], 'filename': ['rgb1', 'rgb2']})
-        stimuli.stimulus_paths = {'1': os.path.join(os.path.dirname(__file__), 'rgb1.jpg'),
-                                  '2': os.path.join(os.path.dirname(__file__), 'rgb2.jpg')}
-        stimuli.identifier = 'TestLabelBehavior.rgb_1_2'
-        return stimuli
+
+def mock_stimulus_set():
+    stimuli = StimulusSet({'stimulus_id': ['1', '2'], 'filename': ['rgb1', 'rgb2']})
+    stimuli.stimulus_paths = {'1': os.path.join(os.path.dirname(__file__), 'rgb1.jpg'),
+                              '2': os.path.join(os.path.dirname(__file__), 'rgb2.jpg')}
+    stimuli.identifier = 'TestLabelBehavior.rgb_1_2'
+    return stimuli
+
+
+class TestLogitsBehavior:
+    """
+    legacy support for LogitsBehavior; still used in old candidate_models submissions
+    https://github.com/brain-score/candidate_models/blob/fa965c452bd17c6bfcca5b991fdbb55fd5db618f/candidate_models/model_commitments/cornets.py#L13
+    """
+
+    def test_import(self):
+        # noinspection PyUnresolvedReferences
+        from model_tools.brain_transformation.behavior import LogitsBehavior
+
+    def test_imagenet(self):
+        from model_tools.brain_transformation.behavior import LogitsBehavior
+
+        activations_model = pytorch_custom()
+        logits_behavior = LogitsBehavior(
+            identifier='pytorch-custom', activations_model=activations_model)
+
+        stimuli = mock_stimulus_set()
+        logits_behavior.start_task(BrainModel.Task.label, 'imagenet')
+        behavior = logits_behavior.look_at(stimuli)
+        assert isinstance(behavior, BehavioralAssembly)
+        assert set(behavior['stimulus_id'].values) == {'1', '2'}
+        assert len(behavior['synset']) == 2
+        assert behavior['synset'].values[0].startswith('n')
 
 
 class TestProbabilitiesMapping:

--- a/tests/brain_transformation/test_behavior.py
+++ b/tests/brain_transformation/test_behavior.py
@@ -50,7 +50,7 @@ class TestLabelBehavior:
         activations_model = model_ctr()
         brain_model = ModelCommitment(identifier=activations_model.identifier, activations_model=activations_model,
                                       layers=None, behavioral_readout_layer='dummy')  # not needed
-        stimuli = self.mock_stimulus_set()
+        stimuli = mock_stimulus_set()
         brain_model.start_task(BrainModel.Task.label, 'imagenet')
         behavior = brain_model.look_at(stimuli)
         assert isinstance(behavior, BehavioralAssembly)


### PR DESCRIPTION
E.g. http://braintree.mit.edu:8080/job/run_benchmarks/2469/console is currently failing with
```
Traceback (most recent call last):
  File "/rdma/vast-rdma/scratch/Fri/score_models_env_2469/brain-score/brainscore/submission/repository.py", line 67, in install_project
    return import_module(package)
  File "/om2/group/dicarlo/jenkins/miniconda3/envs/score_models_2469/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/om2/scratch/Fri/score_models_env_2469/work_dir/candidate_models/models/base_models.py", line 1, in <module>
    from candidate_models.base_models import base_model_pool
  File "/om2/scratch/Fri/score_models_env_2469/work_dir/candidate_models/candidate_models/__init__.py", line 4, in <module>
    from candidate_models.model_commitments import brain_translated_pool
  File "/om2/scratch/Fri/score_models_env_2469/work_dir/candidate_models/candidate_models/model_commitments/__init__.py", line 3, in <module>
    from candidate_models.model_commitments.cornets import cornet_brain_pool
  File "/om2/scratch/Fri/score_models_env_2469/work_dir/candidate_models/candidate_models/model_commitments/cornets.py", line 13, in <module>
    from model_tools.brain_transformation.behavior import BehaviorArbiter, LogitsBehavior, ProbabilitiesMapping
ImportError: cannot import name 'LogitsBehavior' from 'model_tools.brain_transformation.behavior' (/om2/scratch/Fri/score_models_env_2469/.local/lib/python3.7/site-packages/model_tools/brain_transformation/behavior.py)
```

This PR adds legacy support for the LogitsBehavior class which should fix that error.