### PR TITLE
Add assertion that at least one base model was specified and throw an error message otherwise.

### DIFF
--- a/model_tools/check_submission/check_models.py
+++ b/model_tools/check_submission/check_models.py
@@ -34,6 +34,7 @@ def check_brain_model_processing(model):
 
 def check_base_models(module):
     module = __import__(module)
+    assert len(module.get_model_list()) >= 1, 'No base models were specified!'
     for model in module.get_model_list():
         layers = module.get_layers(model)
         assert layers is not None


### PR DESCRIPTION

Closes #46 