### PR TITLE
Add microsaccades to Brain-Score core

### DIFF
--- a/model_tools/activations/core.py
+++ b/model_tools/activations/core.py
@@ -289,10 +289,10 @@ class ActivationsExtractorHelper:
     def _package_layer(self, layer_activations, layer, stimuli_paths, model_requirements):
         if model_requirements is not None and 'microsaccades' in model_requirements.keys():
             runs_per_image = len(model_requirements['microsaccades'])
-            stimuli_paths = np.repeat(stimuli_paths, runs_per_image)
         else:
             runs_per_image = 1
         assert layer_activations.shape[0] == len(stimuli_paths) * runs_per_image
+        stimuli_paths = np.repeat(stimuli_paths, runs_per_image)
         activations, flatten_indices = flatten(layer_activations, return_index=True)  # collapse for single neuroid dim
         flatten_coord_names = None
         if flatten_indices.shape[1] == 1:  # fully connected, e.g. classifier

--- a/model_tools/activations/core.py
+++ b/model_tools/activations/core.py
@@ -48,6 +48,9 @@ class ActivationsExtractorHelper:
             The goal of microsaccades is to obtain multiple different neural activities to the same input stimulus
             from non-stochastic models. This is to improve estimates of e.g. psychophysical functions, but also other
             things.
+            Example usage:
+                model_requirements = {'microsaccades': [(0, 0), (0, 1), (1, 0), (1, 1)]}
+            More information:
             --> Rolfs 2009 "Microsaccades: Small steps on a long way" Vision Research, Volume 49, Issue 20, 15
             October 2009, Pages 2415-2441.
             --> Haddad & Steinmann 1973 "The smallest voluntary saccade: Implications for fixation" Vision

--- a/model_tools/activations/core.py
+++ b/model_tools/activations/core.py
@@ -230,8 +230,7 @@ class ActivationsExtractorHelper:
             temp_file_paths.append(fp)
         preprocessed_images = self.preprocess(temp_file_paths)
         for temp_file_path in temp_file_paths:
-            # os.remove(temp_file_path)
-            pass
+            os.remove(temp_file_path)
         return preprocessed_images
 
     def translate_image(self, image_path: str, shift: np.array) -> str:

--- a/model_tools/activations/core.py
+++ b/model_tools/activations/core.py
@@ -153,6 +153,7 @@ class ActivationsExtractorHelper:
 
     def _get_activations_with_model_requirements(self, paths, layers, model_requirements):
         if model_requirements is not None and 'microsaccades' in model_requirements.keys():
+            assert len(model_requirements['microsaccades'] > 0)
             return self._get_microsaccade_activations_batched(paths, layers=layers, batch_size=self._batch_size,
                                                               shifts=model_requirements['microsaccades'])
         return self._get_activations_batched(paths, layers=layers, batch_size=self._batch_size)

--- a/model_tools/activations/core.py
+++ b/model_tools/activations/core.py
@@ -1,5 +1,7 @@
 import copy
 import os
+import cv2
+import tempfile
 
 import functools
 import logging

--- a/model_tools/activations/core.py
+++ b/model_tools/activations/core.py
@@ -47,7 +47,8 @@ class ActivationsExtractorHelper:
             Human microsaccade amplitude varies by who you ask, an estimate might be <0.1 deg = 360 arcsec = 6arcmin.
             The goal of microsaccades is to obtain multiple different neural activities to the same input stimulus
             from non-stochastic models. This is to improve estimates of e.g. psychophysical functions, but also other
-            things.
+            things. Note that microsaccades are also applied to stochastic models to make them comparable within-
+            benchmark to non-stochastic models.
             Example usage:
                 model_requirements = {'microsaccades': [(0, 0), (0, 1), (1, 0), (1, 1)]}
             More information:
@@ -179,6 +180,9 @@ class ActivationsExtractorHelper:
         return layer_activations
 
     def _get_microsaccade_activations_batched(self, paths, layers, batch_size, shifts):
+        """
+        :param shifts: a list of tuples containing the pixel shifts to apply to the paths.
+        """
         runs_per_image = len(shifts)
         batch_size = batch_size // runs_per_image
         layer_activations = None

--- a/model_tools/activations/core.py
+++ b/model_tools/activations/core.py
@@ -152,7 +152,7 @@ class ActivationsExtractorHelper:
         return handle
 
     def _get_activations_with_model_requirements(self, paths, layers, model_requirements):
-        if 'microsaccades' in model_requirements.keys():
+        if model_requirements is not None and 'microsaccades' in model_requirements.keys():
             return self._get_microsaccade_activations_batched(paths, layers=layers, batch_size=self._batch_size,
                                                               shifts=model_requirements['microsaccades'])
         return self._get_activations_batched(paths, layers=layers, batch_size=self._batch_size)
@@ -279,7 +279,7 @@ class ActivationsExtractorHelper:
         return model_assembly
 
     def _package_layer(self, layer_activations, layer, stimuli_paths, model_requirements):
-        if 'microsaccades' in model_requirements.keys():
+        if model_requirements is not None and 'microsaccades' in model_requirements.keys():
             runs_per_image = len(model_requirements['microsaccades'])
             stimuli_paths = np.repeat(stimuli_paths, runs_per_image)
         else:
@@ -364,7 +364,7 @@ def lstrip_local(path):
 
 
 def attach_stimulus_set_meta(assembly, stimulus_set, model_requirements):
-    if 'microsaccades' in model_requirements.keys():
+    if model_requirements is not None and 'microsaccades' in model_requirements.keys():
         return attach_stimulus_set_meta_with_microsaccades(assembly, stimulus_set, model_requirements)
     stimulus_paths = [str(stimulus_set.get_stimulus(stimulus_id)) for stimulus_id in stimulus_set['stimulus_id']]
     stimulus_paths = [lstrip_local(path) for path in stimulus_paths]

--- a/model_tools/activations/core.py
+++ b/model_tools/activations/core.py
@@ -246,7 +246,7 @@ class ActivationsExtractorHelper:
 
     def _pad(self, batch_images, batch_size, runs_per_image=1):
         num_images = len(batch_images)
-        if (num_images * runs_per_image) % batch_size == 0:
+        if ((num_images * runs_per_image) % batch_size == 0) or num_images < batch_size:
             return batch_images, 0
         num_padding = batch_size * runs_per_image - (num_images % (batch_size * runs_per_image))
         padding = np.repeat(batch_images[-runs_per_image:], repeats=num_padding, axis=0)

--- a/model_tools/activations/core.py
+++ b/model_tools/activations/core.py
@@ -157,7 +157,7 @@ class ActivationsExtractorHelper:
 
     def _get_activations_with_model_requirements(self, paths, layers, model_requirements):
         if model_requirements is not None and 'microsaccades' in model_requirements.keys():
-            assert len(model_requirements['microsaccades'] > 0)
+            assert len(model_requirements['microsaccades']) > 0
             return self._get_microsaccade_activations_batched(paths, layers=layers, batch_size=self._batch_size,
                                                               shifts=model_requirements['microsaccades'])
         return self._get_activations_batched(paths, layers=layers, batch_size=self._batch_size)

--- a/model_tools/activations/core.py
+++ b/model_tools/activations/core.py
@@ -184,7 +184,7 @@ class ActivationsExtractorHelper:
         :param shifts: a list of tuples containing the pixel shifts to apply to the paths.
         """
         runs_per_image = len(shifts)
-        batch_size = batch_size // runs_per_image
+        batch_size = max(batch_size // runs_per_image, 1)
         layer_activations = None
         for batch_start in tqdm(range(0, len(paths), batch_size), unit_scale=batch_size, desc="activations"):
             batch_end = min(batch_start + batch_size, len(paths))

--- a/model_tools/brain_transformation/neural.py
+++ b/model_tools/brain_transformation/neural.py
@@ -24,6 +24,27 @@ class LayerMappedModel(BrainModel):
         return self._identifier
 
     def look_at(self, stimuli, number_of_trials=1, model_requirements: Optional[Dict[str, List]] = None):
+        """
+        :param model_requirements: a dictionary containing any requirements a benchmark might have for models, e.g.
+            microsaccades for getting variable responses from non-stochastic models to the same stimuli.
+
+            model_requirements['microsaccades']: list of tuples of x and y shifts to apply to each image to model
+            microsaccades. Note that the shifts happen in pixel space of the original input image, not the preprocessed
+            image.
+            Human microsaccade amplitude varies by who you ask, an estimate might be <0.1 deg = 360 arcsec = 6arcmin.
+            The goal of microsaccades is to obtain multiple different neural activities to the same input stimulus
+            from non-stochastic models. This is to improve estimates of e.g. psychophysical functions, but also other
+            things.
+            Example usage:
+                model_requirements = {'microsaccades': [(0, 0), (0, 1), (1, 0), (1, 1)]}
+            More information:
+            --> Rolfs 2009 "Microsaccades: Small steps on a long way" Vision Research, Volume 49, Issue 20, 15
+            October 2009, Pages 2415-2441.
+            --> Haddad & Steinmann 1973 "The smallest voluntary saccade: Implications for fixation" Vision
+            Research Volume 13, Issue 6, June 1973, Pages 1075-1086, IN5-IN6.
+            Huge thanks to Johannes Mehrer for the implementation of microsaccades in the Brain-Score core.py and
+            neural.py files.
+        """
         layer_regions = {}
         for region in self.recorded_regions:
             layers = self.region_layer_map[region]

--- a/model_tools/brain_transformation/neural.py
+++ b/model_tools/brain_transformation/neural.py
@@ -34,7 +34,8 @@ class LayerMappedModel(BrainModel):
             Human microsaccade amplitude varies by who you ask, an estimate might be <0.1 deg = 360 arcsec = 6arcmin.
             The goal of microsaccades is to obtain multiple different neural activities to the same input stimulus
             from non-stochastic models. This is to improve estimates of e.g. psychophysical functions, but also other
-            things.
+            things. Note that microsaccades are also applied to stochastic models to make them comparable within-
+            benchmark to non-stochastic models.
             Example usage:
                 model_requirements = {'microsaccades': [(0, 0), (0, 1), (1, 0), (1, 1)]}
             More information:

--- a/model_tools/brain_transformation/neural.py
+++ b/model_tools/brain_transformation/neural.py
@@ -1,6 +1,6 @@
 import logging
 from tqdm import tqdm
-from typing import Optional, Union
+from typing import Optional, Union, Dict, List
 
 from brainscore.metrics import Score
 from brainscore.model_interface import BrainModel
@@ -23,7 +23,7 @@ class LayerMappedModel(BrainModel):
     def identifier(self):
         return self._identifier
 
-    def look_at(self, stimuli, number_of_trials=1):
+    def look_at(self, stimuli, number_of_trials=1, model_requirements: Optional[Dict[str, List]] = None):
         layer_regions = {}
         for region in self.recorded_regions:
             layers = self.region_layer_map[region]
@@ -31,12 +31,15 @@ class LayerMappedModel(BrainModel):
             for layer in layers:
                 assert layer not in layer_regions, f"layer {layer} has already been assigned for {layer_regions[layer]}"
                 layer_regions[layer] = region
-        activations = self.run_activations(stimuli, layers=list(layer_regions.keys()), number_of_trials=number_of_trials)
+        activations = self.run_activations(stimuli,
+                                           layers=list(layer_regions.keys()),
+                                           number_of_trials=number_of_trials,
+                                           model_requirements=model_requirements)
         activations['region'] = 'neuroid', [layer_regions[layer] for layer in activations['layer'].values]
         return activations
 
-    def run_activations(self, stimuli, layers, number_of_trials=1):
-        activations = self.activations_model(stimuli, layers=layers)
+    def run_activations(self, stimuli, layers, number_of_trials=1, model_requirements=None):
+        activations = self.activations_model(stimuli, layers=layers, model_requirements=model_requirements)
         return activations
 
     def start_task(self, task):

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ requirements = [
     "keras==2.3.1",
     "protobuf<4",  # keras import fails on newer protobuf http://braintree.mit.edu:8080/job/unittest_model_tools/132/
     "scikit-learn",
+    "opencv-python",
     "result_caching @ git+https://github.com/brain-score/result_caching",
 ]
 

--- a/tests/activations/test___init__.py
+++ b/tests/activations/test___init__.py
@@ -195,7 +195,7 @@ def test_from_image_path(model_ctr, layers, image_name, pca_components, logits):
 @pytest.mark.parametrize(["model_ctr", "layers"], models_layers)
 @pytest.mark.parametrize("shifts", [[(2, 2), (0, 0), (1, -1), (0, 1)], [(0, 1), (2, 3)]])
 def test_microsaccades_from_image_path(model_ctr, layers, image_name, shifts):
-    stimulus_paths = [os.path.join(os.path.dirname(__file__), image_name)]  # Replace with a suitable test image
+    stimulus_paths = [os.path.join(os.path.dirname(__file__), image_name)]
     activations_extractor = model_ctr()
 
     model_requirements = {'microsaccades': shifts}
@@ -212,7 +212,7 @@ def test_microsaccades_from_image_path(model_ctr, layers, image_name, shifts):
 @pytest.mark.parametrize(["model_ctr", "layers"], models_layers)
 @pytest.mark.parametrize("model_requirements", [None, {'microsaccades': [(0, 0), (1, -1)]}])
 def test_model_requirements(model_ctr, layers, image_name, model_requirements):
-    stimulus_paths = [os.path.join(os.path.dirname(__file__), image_name)]  # Replace with a suitable test image
+    stimulus_paths = [os.path.join(os.path.dirname(__file__), image_name)]
     activations_extractor = model_ctr()
 
     activations_with_req = activations_extractor(stimuli=stimulus_paths, layers=layers,
@@ -233,7 +233,7 @@ def test_model_requirements(model_ctr, layers, image_name, model_requirements):
 @pytest.mark.parametrize(["model_ctr", "layers"], models_layers)
 def test_temporary_file_handling(model_ctr, layers, image_name):
     import tempfile
-    stimulus_paths = [os.path.join(os.path.dirname(__file__), image_name)]  # Replace with a suitable test image
+    stimulus_paths = [os.path.join(os.path.dirname(__file__), image_name)]
     activations_extractor = model_ctr()
     model_requirements = {'microsaccades': [(2, 2)]}
 
@@ -241,7 +241,7 @@ def test_temporary_file_handling(model_ctr, layers, image_name):
     temp_files = [f for f in os.listdir(tempfile.gettempdir()) if f.startswith('temp') and f.endswith('.png')]
 
     assert activations is not None
-    assert len(temp_files) == 0  # No temporary files should remain
+    assert len(temp_files) == 0
 
 
 def _build_stimulus_set(image_names):

--- a/tests/activations/test___init__.py
+++ b/tests/activations/test___init__.py
@@ -224,9 +224,8 @@ def test_model_requirements(model_ctr, layers, image_name, model_requirements):
     assert activations_with_req is not None
     assert activations_without_req is not None
     if model_requirements:
-        assert len(activations_with_req['neuroid']) > len(activations_without_req['neuroid'])
-    else:
-        assert len(activations_with_req['neuroid']) == len(activations_without_req['neuroid'])
+        assert len(activations_with_req['presentation']) > len(activations_without_req['presentation'])
+    assert len(activations_with_req['neuroid']) == len(activations_without_req['neuroid'])
 
 
 @pytest.mark.parametrize("image_name", ['rgb.jpg', 'grayscale.png', 'grayscale2.jpg', 'grayscale_alpha.png',

--- a/tests/activations/test___init__.py
+++ b/tests/activations/test___init__.py
@@ -202,7 +202,8 @@ def test_microsaccades_from_image_path(model_ctr, layers, image_name, shifts):
     activations = activations_extractor(stimuli=stimulus_paths, layers=layers, model_requirements=model_requirements)
 
     assert activations is not None
-    assert 'shift_x' in activations.coords and 'shift_y' in activations.coords
+    assert list(activations['shift_x'].values) == [shift[0] for shift in shifts]
+    assert list(activations['shift_y'].values) == [shift[1] for shift in shifts]
     assert len(activations['shift_x']) == len(shifts) * len(stimulus_paths)
     assert len(activations['shift_y']) == len(shifts) * len(stimulus_paths)
 

--- a/tests/activations/test___init__.py
+++ b/tests/activations/test___init__.py
@@ -5,6 +5,7 @@ import pytest
 import xarray as xr
 from pathlib import Path
 
+
 from brainio.stimuli import StimulusSet
 from model_tools.activations import KerasWrapper, PytorchWrapper, TensorflowSlimWrapper
 from model_tools.activations.core import flatten
@@ -187,6 +188,60 @@ def test_from_image_path(model_ctr, layers, image_name, pca_components, logits):
     import gc
     gc.collect()  # free some memory, we're piling up a lot of activations at this point
     return activations
+
+
+@pytest.mark.parametrize("image_name", ['rgb.jpg', 'grayscale.png', 'grayscale2.jpg', 'grayscale_alpha.png',
+                                        'palletized.png'])
+@pytest.mark.parametrize(["model_ctr", "layers"], models_layers)
+@pytest.mark.parametrize("shifts", [[(2, 2), (0, 0), (1, -1), (0, 1)], [(0, 1), (2, 3)]])
+def test_microsaccades_from_image_path(model_ctr, layers, image_name, shifts):
+    stimulus_paths = [os.path.join(os.path.dirname(__file__), image_name)]  # Replace with a suitable test image
+    activations_extractor = model_ctr()
+
+    model_requirements = {'microsaccades': shifts}
+    activations = activations_extractor(stimuli=stimulus_paths, layers=layers, model_requirements=model_requirements)
+
+    assert activations is not None
+    assert 'shift_x' in activations.coords and 'shift_y' in activations.coords
+    assert len(activations['shift_x']) == len(shifts) * len(stimulus_paths)
+    assert len(activations['shift_y']) == len(shifts) * len(stimulus_paths)
+
+
+@pytest.mark.parametrize("image_name", ['rgb.jpg', 'grayscale.png', 'grayscale2.jpg', 'grayscale_alpha.png',
+                                        'palletized.png'])
+@pytest.mark.parametrize(["model_ctr", "layers"], models_layers)
+@pytest.mark.parametrize("model_requirements", [None, {'microsaccades': [(0, 0), (1, -1)]}])
+def test_model_requirements(model_ctr, layers, image_name, model_requirements):
+    stimulus_paths = [os.path.join(os.path.dirname(__file__), image_name)]  # Replace with a suitable test image
+    activations_extractor = model_ctr()
+
+    activations_with_req = activations_extractor(stimuli=stimulus_paths, layers=layers,
+                                                 model_requirements=model_requirements)
+    activations_without_req = activations_extractor(stimuli=stimulus_paths, layers=layers,
+                                                    model_requirements=None)
+
+    assert activations_with_req is not None
+    assert activations_without_req is not None
+    if model_requirements:
+        assert len(activations_with_req['neuroid']) > len(activations_without_req['neuroid'])
+    else:
+        assert len(activations_with_req['neuroid']) == len(activations_without_req['neuroid'])
+
+
+@pytest.mark.parametrize("image_name", ['rgb.jpg', 'grayscale.png', 'grayscale2.jpg', 'grayscale_alpha.png',
+                                        'palletized.png'])
+@pytest.mark.parametrize(["model_ctr", "layers"], models_layers)
+def test_temporary_file_handling(model_ctr, layers, image_name):
+    import tempfile
+    stimulus_paths = [os.path.join(os.path.dirname(__file__), image_name)]  # Replace with a suitable test image
+    activations_extractor = model_ctr()
+    model_requirements = {'microsaccades': [(2, 2)]}
+
+    activations = activations_extractor(stimuli=stimulus_paths, layers=layers, model_requirements=model_requirements)
+    temp_files = [f for f in os.listdir(tempfile.gettempdir()) if f.startswith('temp') and f.endswith('.png')]
+
+    assert activations is not None
+    assert len(temp_files) == 0  # No temporary files should remain
 
 
 def _build_stimulus_set(image_names):


### PR DESCRIPTION
In this PR we add microsaccades to Brain-Score core.

**Conceptual Problem**: We need variance in model responses to static stimuli. 

**Conceptual Solution**: Microsaccades are a prevalent phenomenon in vision and visual experiments. They are involuntary movements of the eye at very small scales. Microsaccades are not (and often can not due to their small extent) be controlled for in experiments, and are thus implicitly baked into the variance in primate responses. As such, microsaccades are a phenomenon that is either explicitly or implicitly believed to be unimportant for behavioral/neural outcomes, and thus a good candidate for getting variance in responses to static stimuli. (e.g. *Rolfs 2009, Vis. Res.*; *Haddad & Steinmann 1973, Vis. Res.*)

**Technical problem**: The current BrainScore interface does not support microsaccades.

**Technical solution**: the [ActivationsExtractorHelper](https://github.com/brain-score/model-tools/blob/75365b54670d3f6f63dcdf88395c0a07d6b286fc/model_tools/activations/core.py#L22) will be changed. The [from_paths](https://github.com/brain-score/model-tools/blob/75365b54670d3f6f63dcdf88395c0a07d6b286fc/model_tools/activations/core.py#L59C9-L59C19) method now takes a path, loads the image from the path, does pixel position jittering to the image, and saves the jittered image into a temporary new path. The new path is passed to the downstream functions to get the model activations.

To accomplish this, the from_paths method will now receive a dictionary of tags. This dictionary of tags comes from a call to the [look_at](https://github.com/brain-score/model-tools/blob/75365b54670d3f6f63dcdf88395c0a07d6b286fc/model_tools/brain_transformation/neural.py#L26C13-L26C13) method, where number_of_trials is replaced with a new dictionary. This new dictionary then traverses the following path:
1. [run_activations](https://github.com/brain-score/model-tools/blob/75365b54670d3f6f63dcdf88395c0a07d6b286fc/model_tools/brain_transformation/neural.py#L38C17-L38C17)
2. A call to [activations_model](https://github.com/brain-score/model-tools/blob/75365b54670d3f6f63dcdf88395c0a07d6b286fc/model_tools/brain_transformation/neural.py#L39)
3. In practice, this calls a [TensorFlowWrapper](https://github.com/brain-score/model-tools/blob/75365b54670d3f6f63dcdf88395c0a07d6b286fc/model_tools/activations/tensorflow.py#L6C16-L6C16)/[PytorchWrapper](https://github.com/brain-score/model-tools/blob/75365b54670d3f6f63dcdf88395c0a07d6b286fc/model_tools/activations/pytorch.py#L13C7-L13C21)/etc.’s [self._extractor](https://github.com/brain-score/model-tools/blob/75365b54670d3f6f63dcdf88395c0a07d6b286fc/model_tools/activations/pytorch.py#L22) class’s \_\_call\_\_() method in its \_\_call\_\_() method. (I.e., [PytorchWrapper](https://github.com/brain-score/model-tools/blob/75365b54670d3f6f63dcdf88395c0a07d6b286fc/model_tools/activations/pytorch.py#L13C7-L13C21).[\_\_call\_\_()](https://github.com/brain-score/model-tools/blob/75365b54670d3f6f63dcdf88395c0a07d6b286fc/model_tools/activations/pytorch.py#L40) => [self._extractor.\_\_call\_\_()](https://github.com/brain-score/model-tools/blob/75365b54670d3f6f63dcdf88395c0a07d6b286fc/model_tools/activations/pytorch.py#L41C23-L41C23) )
4. This extractor’s call method is [ActivationsExtractorHelper.\_\_call\_\_()](https://github.com/brain-score/model-tools/blob/75365b54670d3f6f63dcdf88395c0a07d6b286fc/model_tools/activations/core.py#L36)
5. Thus we pass the new dictionary to [ActivationsExtractorHelper.\_\_call\_\_()](https://github.com/brain-score/model-tools/blob/75365b54670d3f6f63dcdf88395c0a07d6b286fc/model_tools/activations/core.py#L36) where it will be parsed.

TODO list:
- [x] Implement microsaccades
- [x] Implement unit tests for microsaccades

Other Brain-Score benchmark PRs depend on this PR ([Malania2007](https://github.com/brain-score/brain-score/pull/365)).

Huge thanks to Hannes Mehrer (@hanme) who implemented microsaccades, which I've only adapted for the generalized case here.